### PR TITLE
feat: add disqusAdWarning i18n translations for Disqus ad notice

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -90,7 +90,9 @@
 - id: show
   translation: "Zeige"
 - id: comments
-  translation: "Kommentare" 
+  translation: "Kommentare"
+- id: disqusAdWarning
+  translation: "Kommentare werden von Disqus bereitgestellt. Im Kommentarbereich kann Werbung angezeigt werden." 
 
 # Related posts
 - id: seeAlso

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -65,7 +65,9 @@
 - id: show
   translation: "Show"
 - id: comments
-  translation: "comments" 
+  translation: "comments"
+- id: disqusAdWarning
+  translation: "Comments are powered by Disqus. You may see ads in the comments section." 
 
 # Related posts
 - id: seeAlso

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -90,7 +90,9 @@
 - id: show
   translation: "Voir"
 - id: comments
-  translation: "commentaires" 
+  translation: "commentaires"
+- id: disqusAdWarning
+  translation: "Les commentaires sont fournis par Disqus. Des publicités peuvent apparaître dans la section commentaires." 
 
 # Related posts
 - id: seeAlso


### PR DESCRIPTION
- English: 'Comments are powered by Disqus. You may see ads in the comments section.'
- German: 'Kommentare werden von Disqus bereitgestellt. Im Kommentarbereich kann Werbung angezeigt werden.'
- French: 'Les commentaires sont fournis par Disqus. Des publicités peuvent apparaître dans la section commentaires.'